### PR TITLE
PMS152 external ocscillator - fix EOSC_ENABLE

### DIFF
--- a/device/periph/external_oscillator.h
+++ b/device/periph/external_oscillator.h
@@ -47,7 +47,7 @@ __sfr __at(EOSCR_ADDR)        _eoscr;
   #define EOSC_32KHZ_CRYSTAL           (1 << EOSC_CRYSTAL_SEL_BIT0)
   #define EOSC_1MHZ_CRYSTAL            (2 << EOSC_CRYSTAL_SEL_BIT0)
   #define EOSC_4MHZ_CRYSTAL            (3 << EOSC_CRYSTAL_SEL_BIT0)
-  #define EOSC_ENABLE                  (1 << EOSC_BG_LVR_SHUTDOWN_BIT)
+  #define EOSC_ENABLE                  (1 << EOSC_ENABLE_BIT)
 #endif
 
 #endif //__PDK_DEVICE_PERIPH_EXTERNAL_OSCILLATOR_H__


### PR DESCRIPTION
For devices capable of using external oscillator the EOSC_ENABLE needs the bit 7.

![image](https://github.com/free-pdk/pdk-includes/assets/12158282/b3055c1f-41e6-4ca7-9e34-44a9ac55e2d9)
